### PR TITLE
Fix for 'Invalid time or time format' error (break missing)

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -168,6 +168,7 @@
             {
                 NSLog(@"Invalid date or date format:%@",selectedItem);
             }
+            break;
         }
         case IQDropDownModeTimePicker:
         {
@@ -183,10 +184,8 @@
             {
                 NSLog(@"Invalid time or time format:%@",selectedItem);
             }
-            
-        }
-            
             break;
+        }
     }
 }
 


### PR DESCRIPTION
Hi guys, I found the missing **break** operator. It showed _'Invalid time or time format'_ for a **IQDropDownModeDatePicker** picker. Please check.
