### PR TITLE
Update IQDropDownTextField.m

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -59,6 +59,13 @@
 @synthesize pickerView,datePicker, timePicker, dropDownDateFormatter,dropDownTimeFormatter;
 @synthesize dateFormatter, timeFormatter;
 
+#pragma mark - NSObject
+
+- (void)dealloc {
+    [self.pickerView setDelegate:nil];
+    [self.pickerView setDataSource:nil];
+}
+
 #pragma mark - Initialization
 
 - (void)initialize


### PR DESCRIPTION
on iOS7 if text field released before keyboard is dismissed app crashes.

Easy way to replicate is to present view controller, click on text field and dismiss view controller while keyboard shows picker