### PR TITLE
change @synthesize to @dynamic for delegate

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -54,7 +54,7 @@
 @synthesize datePickerMode = _datePickerMode;
 @synthesize minimumDate = _minimumDate;
 @synthesize maximumDate = _maximumDate;
-@synthesize delegate;
+@dynamic delegate;
 
 @synthesize pickerView,datePicker, timePicker, dropDownDateFormatter,dropDownTimeFormatter;
 @synthesize dateFormatter, timeFormatter;


### PR DESCRIPTION
change @synthesize to @dynamic for delegate
if use @synthesize for delegate, you can’t get the UITextFieldDelegate
event, so need to use @dynamic.