### PR TITLE
doest adjust Text Picker View label Text into Width

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.h
+++ b/IQDropDownTextField/IQDropDownTextField.h
@@ -127,6 +127,11 @@ typedef NS_ENUM(NSInteger, IQDropDownMode) {
 @property (nonatomic, assign) NSInteger selectedRow;
 
 /**
+ Defines Picker labels fontSizeAdjustment by width. Default is NO
+ */
+@property (nonatomic, assign) BOOL adjustPickerLabelFontSizeWidth;
+
+/**
  Select row index of selected item.
  */
 - (void)setSelectedRow:(NSInteger)row animated:(BOOL)animated;

--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -55,6 +55,7 @@
 @synthesize minimumDate = _minimumDate;
 @synthesize maximumDate = _maximumDate;
 @synthesize optionalItemText = _optionalItemText;
+@synthesize adjustPickerLabelFontSizeWidth = _adjustPickerLabelFontSizeWidth;
 
 @dynamic delegate;
 
@@ -97,6 +98,7 @@
 	
     [self setDropDownMode:IQDropDownModeTextPicker];
     [self setIsOptionalDropDown:YES];
+    [self setAdjustPickerLabelFontSizeWidth:NO];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -157,6 +159,7 @@
     {
         labelText.font = [UIFont boldSystemFontOfSize:18.0];
         labelText.textColor = [UIColor blackColor];
+        labelText.adjustsFontSizeToFitWidth = self.adjustPickerLabelFontSizeWidth;
     }
     return labelText;
 }
@@ -453,6 +456,16 @@
 {
     _optionalItemText = [optionalItemText copy];
 
+    [self _updateOptionsList];
+}
+
+-(BOOL)adjustPickerLabelFontSizeWidth {
+    return _adjustPickerLabelFontSizeWidth;
+}
+
+-(void)setAdjustPickerLabelFontSizeWidth:(BOOL)adjustPickerLabelFontSizeWidth {
+    _adjustPickerLabelFontSizeWidth = adjustPickerLabelFontSizeWidth;
+    
     [self _updateOptionsList];
 }
 


### PR DESCRIPTION
I have changed PickerView Labels fontSizeAdjustment for Fit Width to be FALSE by default. and can toggle. If you find this useful you can merge this )
It's not backward compatible, if it's matter you can remove line in initialize before commit.