### PR TITLE
fix dealloc crash when pickerView was not initialised

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -70,8 +70,8 @@
 #pragma mark - NSObject
 
 - (void)dealloc {
-    [self.pickerView setDelegate:nil];
-    [self.pickerView setDataSource:nil];
+    [_pickerView setDelegate:nil];
+    [_pickerView setDataSource:nil];
 }
 
 #pragma mark - Initialization


### PR DESCRIPTION
Using property here may trigger lazy initialisation on dealloc, which seems to crash the app.