### PR TITLE
Deadlock Issue

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.h
+++ b/IQDropDownTextField/IQDropDownTextField.h
@@ -129,7 +129,7 @@ typedef NS_ENUM(NSInteger, IQProposedSelection) {
 /**
  Use selectedItem property to get/set dropdown text.
  */
-@property(nullable, nonatomic,copy)   NSString               *text NS_DEPRECATED_IOS(3_0, 5_0, "Please use selectedItem property to get/set dropdown selected text instead");
+@property(nullable, nonatomic,copy)   NSString               *text;
 
 /**
  attributedText is unavailable in IQDropDownTextField.

--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -321,6 +321,18 @@
 }
 
 #pragma mark - Setters
+
+-(void)setText:(NSString *)text
+{
+    //Checking if the set value is available in the options list or not
+    if ([_itemList containsObject:text]) {
+        _selectedItem = text;
+        super.text = text;
+    }
+    else @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Externally setting  a value  which is not in the item list.Please check the value you are setting %@ in %@", NSStringFromSelector(_cmd),NSStringFromClass([self class])]
+                                     userInfo:nil];
+}
+
 - (void)setDropDownMode:(IQDropDownMode)dropDownMode
 {
     _dropDownMode = dropDownMode;


### PR DESCRIPTION
#pragma - mark IQDropDownTextFieldDelegate

```
- (void)textField:(IQDropDownTextField *)textField didSelectItem:(NSString *)item
{
//Both the textfield must have the same value
    if (textField == self.tf1) self.tf2.selectedItem = self.tf1.selectedItem;
    else if (textField == self.tf2) self.tf1.selectedItem = self.tf2.selectedItem;
}
```
it will create deadlock as follow
```
-(void)setSelectedItem:(NSString *)selectedItem animated:(BOOL)animated
{
    switch (_dropDownMode)
    {
        case IQDropDownModeTextPicker:
            if ([_ItemListsInternal containsObject:selectedItem])
            {
                _selectedItem = selectedItem;
                
                [self setSelectedRow:[_ItemListsInternal indexOfObject:selectedItem] animated:animated];
                
            **    if ([self.delegate respondsToSelector:@selector(textField:didSelectItem:)])
                    [self.delegate textField:self didSelectItem:_selectedItem]; **
            }
            break;
        case IQDropDownModeDatePicker:

```

#pragma - mark IQDropDownTextFieldDelegate

```

I have done this (with warning) so please expose a method to get / set selected item for multiple TFs or merge this to make text accessible without warning.
- (void)textField:(IQDropDownTextField *)textField didSelectItem:(NSString *)item
{
//Both the textfield must have the same value
    if (textField == self.tf1) self.tf2.text = self.tf1.text;
    else if (textField == self.tf2) self.tf1.text = self.tf2.text;
}

```