### PR TITLE
When using IQDropDownModeTextField, the user should be able to cut & paste

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -735,9 +735,10 @@ NSInteger const IQOptionalTextFieldIndex =  -1;
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
-    if (action == @selector(paste:) || action == @selector(cut:))
+    BOOL isRestrictedAction = (action == @selector(paste:) || action == @selector(cut:));
+    if (isRestrictedAction && self.dropDownMode != IQDropDownModeTextField) {
         return NO;
-    
+    }
     
     return [super canPerformAction:action withSender:sender];
 }


### PR DESCRIPTION
When using IQDropDownModeTextField, the user should be able to cut & paste