### PR TITLE
Date property when using DateTime picker not working

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -434,7 +434,7 @@ NSInteger const IQOptionalTextFieldIndex =  -1;
             }
             else
             {
-                return [self.timePicker.date copy];
+                return [self.dateTimePicker.date copy];
             }
         }
         default:                        return  nil;                     break;


### PR DESCRIPTION
Just a small copy paste error.
When using the date time picker, the date getter was using the date property of the TimePicker instead of the correct picker.