### PR TITLE
Ensure that parsed times are relative to the reference date

### DIFF
--- a/IQDropDownTextField/IQDropDownTextField.m
+++ b/IQDropDownTextField/IQDropDownTextField.m
@@ -596,7 +596,7 @@ NSInteger const IQOptionalTextFieldIndex =  -1;
         }
         case IQDropDownModeTimePicker:
         {
-            NSDate *date = [self.dropDownTimeFormatter dateFromString:selectedItem];
+            NSDate *date = [self parseTime: selectedItem];
             if (date)
             {
                 super.text = selectedItem;
@@ -764,6 +764,20 @@ NSInteger const IQOptionalTextFieldIndex =  -1;
     }
     
     return [super canPerformAction:action withSender:sender];
+}
+
+- (NSDate *)parseTime:(NSString *)text {
+	NSDate *day = [NSDate dateWithTimeIntervalSinceNow: 0];
+	NSDate *time = [self.dropDownTimeFormatter dateFromString: text];
+
+	NSDateComponents *componentsDay = [[NSCalendar currentCalendar] components: NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate: day];
+	NSDateComponents *componentsTime = [[NSCalendar currentCalendar] components: NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate: time];
+	componentsDay.hour = componentsTime.hour;
+	componentsDay.minute = componentsTime.minute;
+	componentsDay.second = componentsTime.second;
+
+	return [[NSCalendar currentCalendar] dateFromComponents: componentsDay];
+
 }
 
 #pragma mark - Getter


### PR DESCRIPTION
`NSDate`s parsed by an `NSDateFormatter` with only time information have undefined year/month/day values.

This becomes an issue when for example, we set the `minimumDate` of a `UIDatePicker` as mentioned in #61