### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Any contribution is more than welcome! You can contribute through pull requests 
 
 If you wish to contact me, email at: hack.iftekhar@gmail.com
 
-##LICENSE
+## LICENSE
 
 Copyright (c) 2010-2015
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
